### PR TITLE
Add promo badges and booking detail overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
       </article>
 
       <!-- 2 -->
-      <article class="card" data-name="Urban Cuts" data-price="25" data-rating="4.6" data-reviews="210" data-promo="Recibirás mensajes exclusivos con ofertas para tentarte a probar nuevos looks.">
+      <article class="card" data-name="Urban Cuts" data-price="25" data-rating="4.6" data-reviews="210" data-promo="¡Oferta relámpago! Si es tu primera vez, desbloquea 20% de descuento y mensajes VIP que te tientan a reinventarte.">
         <div class="thumb">
           <!-- cool teal studio -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -173,7 +173,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="#1d3b31" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M4 6h16v12H4z"/><path d="M4 6l8 6 8-6"/>
             </svg>
-            Mensajes con ofertas para tentar tu cambio
+            ¡Oferta relámpago! 20% OFF para nuevos looks
           </div>
           <h3 class="title">Urban Cuts</h3>
           <p class="sub">Desde 25 €</p>
@@ -231,7 +231,7 @@
       </article>
 
       <!-- 5 -->
-      <article class="card" data-name="Style Street Barbers" data-price="29" data-rating="4.7" data-reviews="87" data-promo="Recibirás recordatorios con promociones chispeantes para que no cambies de idea.">
+      <article class="card" data-name="Style Street Barbers" data-price="29" data-rating="4.7" data-reviews="87" data-promo="¡Descuento secreto! Si es tu primera visita, te mandamos alertas chispeantes con upgrades gratis para que no cambies de idea.">
         <div class="thumb">
           <!-- dark moody -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -245,7 +245,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="#1d3b31" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M4 6h16v12H4z"/><path d="M4 6l8 6 8-6"/>
             </svg>
-            Promos directas a tu bandeja de entrada
+            ¡Descuento secreto! Alertas chispeantes
           </div>
           <h3 class="title">Style Street Barbers</h3>
           <p class="sub">Desde 29 €</p>
@@ -326,7 +326,7 @@
       </article>
 
       <!-- 9 -->
-      <article class="card" data-name="Trim &amp; Proper" data-price="17" data-rating="4.5" data-reviews="89" data-promo="Mensajes sorpresa con upgrades para que no puedas resistirte a reservar.">
+      <article class="card" data-name="Trim &amp; Proper" data-price="17" data-rating="4.5" data-reviews="89" data-promo="¡Promo cambiacitos! Mensajes sorpresa con barba spa gratis si reservas ya mismo.">
         <div class="thumb">
           <!-- green walls -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -340,7 +340,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="#1d3b31" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M4 6h16v12H4z"/><path d="M4 6l8 6 8-6"/>
             </svg>
-            Mensajes que te tientan con mejoras
+            ¡Promo cambiacitos! Barba spa gratis
           </div>
           <h3 class="title">Trim &amp; Proper</h3>
           <p class="sub">Desde 17 €</p>

--- a/index.html
+++ b/index.html
@@ -68,9 +68,35 @@
       font-weight:700;font-size:14px;box-shadow:0 4px 10px rgba(23,106,79,.25);
     }
     .btn:active{background:var(--accent-press);transform:translateY(1px)}
+    .promo-badge{
+      display:inline-flex;align-items:center;gap:6px;background:var(--pill);color:#14532d;font-size:12px;font-weight:600;
+      padding:6px 10px;border-radius:999px;margin-bottom:8px;
+    }
+    .promo-badge svg{width:16px;height:16px}
+    .detail{
+      position:fixed;inset:0;background:rgba(16,20,24,.55);display:flex;justify-content:center;align-items:flex-end;
+      padding:24px;box-sizing:border-box;z-index:20;
+    }
+    .detail[hidden]{display:none}
+    .detail-card{
+      background:var(--card);border-radius:28px 28px 0 0;padding:28px 24px 36px;width:100%;max-width:540px;
+      box-shadow:0 -12px 40px rgba(12,20,33,.22);
+      animation:slideup .28s ease;
+    }
+    .detail-card:focus{outline:2px solid var(--accent);outline-offset:4px}
+    .detail-header{display:flex;align-items:flex-start;gap:12px;margin-bottom:16px}
+    .detail-title{font-size:22px;font-weight:800;margin:0;color:var(--text)}
+    .detail-close{
+      margin-left:auto;background:transparent;border:none;color:var(--muted);font-size:14px;font-weight:600;
+    }
+    .detail-info{display:flex;gap:12px;color:var(--muted);font-size:14px;margin-bottom:16px}
+    .detail-info span{display:flex;align-items:center;gap:6px}
+    .detail-info strong{color:var(--text);font-weight:700}
+    .detail-message{background:var(--pill);padding:14px 16px;border-radius:16px;font-size:14px;color:#1d3b31;margin-bottom:20px}
+    .detail-actions{display:flex;gap:12px}
+    .detail-actions .btn{flex:1;justify-content:center;display:inline-flex;align-items:center;text-align:center}
+    @keyframes slideup{from{transform:translateY(20px);opacity:0}to{transform:translateY(0);opacity:1}}
     .footer-space{height:80px}
-    /* Small helper for demo: extend page a lot for real scroll */
-    .spacer{height:6px}
   </style>
 </head>
 <body>
@@ -128,7 +154,7 @@
       </article>
 
       <!-- 2 -->
-      <article class="card" data-name="Urban Cuts" data-price="25" data-rating="4.6" data-reviews="210">
+      <article class="card" data-name="Urban Cuts" data-price="25" data-rating="4.6" data-reviews="210" data-promo="Recibirás mensajes exclusivos con ofertas para tentarte a probar nuevos looks.">
         <div class="thumb">
           <!-- cool teal studio -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -143,6 +169,12 @@
           </svg>
         </div>
         <div>
+          <div class="promo-badge" aria-label="Oferta con mensajes tentadores">
+            <svg viewBox="0 0 24 24" fill="none" stroke="#1d3b31" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M4 6h16v12H4z"/><path d="M4 6l8 6 8-6"/>
+            </svg>
+            Mensajes con ofertas para tentar tu cambio
+          </div>
           <h3 class="title">Urban Cuts</h3>
           <p class="sub">Desde 25 €</p>
           <div class="row">
@@ -199,7 +231,7 @@
       </article>
 
       <!-- 5 -->
-      <article class="card" data-name="Style Street Barbers" data-price="29" data-rating="4.7" data-reviews="87">
+      <article class="card" data-name="Style Street Barbers" data-price="29" data-rating="4.7" data-reviews="87" data-promo="Recibirás recordatorios con promociones chispeantes para que no cambies de idea.">
         <div class="thumb">
           <!-- dark moody -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -209,6 +241,12 @@
           </svg>
         </div>
         <div>
+          <div class="promo-badge" aria-label="Oferta con mensajes tentadores">
+            <svg viewBox="0 0 24 24" fill="none" stroke="#1d3b31" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M4 6h16v12H4z"/><path d="M4 6l8 6 8-6"/>
+            </svg>
+            Promos directas a tu bandeja de entrada
+          </div>
           <h3 class="title">Style Street Barbers</h3>
           <p class="sub">Desde 29 €</p>
           <div class="row">
@@ -288,7 +326,7 @@
       </article>
 
       <!-- 9 -->
-      <article class="card" data-name="Trim &amp; Proper" data-price="17" data-rating="4.5" data-reviews="89">
+      <article class="card" data-name="Trim &amp; Proper" data-price="17" data-rating="4.5" data-reviews="89" data-promo="Mensajes sorpresa con upgrades para que no puedas resistirte a reservar.">
         <div class="thumb">
           <!-- green walls -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -298,6 +336,12 @@
           </svg>
         </div>
         <div>
+          <div class="promo-badge" aria-label="Oferta con mensajes tentadores">
+            <svg viewBox="0 0 24 24" fill="none" stroke="#1d3b31" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M4 6h16v12H4z"/><path d="M4 6l8 6 8-6"/>
+            </svg>
+            Mensajes que te tientan con mejoras
+          </div>
           <h3 class="title">Trim &amp; Proper</h3>
           <p class="sub">Desde 17 €</p>
           <div class="row">
@@ -328,12 +372,6 @@
           </div>
         </div>
       </article>
-
-      <!-- Spacer to ensure long scroll feel -->
-      <div class="spacer"></div>
-      <div class="spacer"></div>
-      <div class="spacer"></div>
-    
       <article class="card" data-name="Fade Masters" data-price="22" data-rating="4.9" data-reviews="156">
         <div class="thumb">
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -545,7 +583,80 @@
       </article>
     </main>
 
+    <div class="detail" hidden aria-hidden="true">
+      <div class="detail-card" role="dialog" aria-modal="true" aria-labelledby="detail-title" tabindex="-1">
+        <div class="detail-header">
+          <h2 class="detail-title" id="detail-title">&nbsp;</h2>
+          <button class="detail-close" type="button">Cerrar</button>
+        </div>
+        <div class="detail-info">
+          <span>💶 <strong class="detail-price"></strong></span>
+          <span>⭐ <strong class="detail-rating"></strong></span>
+          <span>🗣️ <strong class="detail-reviews"></strong></span>
+        </div>
+        <div class="detail-message"></div>
+        <div class="detail-actions">
+          <button class="btn detail-book" type="button">Continuar con la reserva</button>
+        </div>
+      </div>
+    </div>
+
     <div class="footer-space"></div>
   </div>
+  <script>
+    const detail = document.querySelector('.detail');
+    const detailTitle = detail.querySelector('.detail-title');
+    const detailPrice = detail.querySelector('.detail-price');
+    const detailRating = detail.querySelector('.detail-rating');
+    const detailReviews = detail.querySelector('.detail-reviews');
+    const detailMessage = detail.querySelector('.detail-message');
+    const detailClose = detail.querySelector('.detail-close');
+    const detailBook = detail.querySelector('.detail-book');
+    let lastTrigger = null;
+
+    function openDetail(card) {
+      const { name, price, rating, reviews, promo } = card.dataset;
+      detailTitle.textContent = name;
+      detailPrice.textContent = `Desde ${price} €`;
+      detailRating.textContent = `${rating} / 5`;
+      detailReviews.textContent = `${reviews} reseñas`;
+      detailMessage.textContent = promo || 'Aquí podrás revisar los servicios, horarios y confirmar tu cita sin salir de la ficha.';
+      detail.hidden = false;
+      detail.setAttribute('aria-hidden', 'false');
+      detailClose.focus({ preventScroll: true });
+    }
+
+    function closeDetail() {
+      detail.hidden = true;
+      detail.setAttribute('aria-hidden', 'true');
+      if (lastTrigger) {
+        lastTrigger.focus({ preventScroll: true });
+      }
+    }
+
+    document.querySelectorAll('.card .btn').forEach(btn => {
+      btn.addEventListener('click', event => {
+        event.preventDefault();
+        const card = event.currentTarget.closest('.card');
+        lastTrigger = event.currentTarget;
+        openDetail(card);
+      });
+    });
+
+    detailClose.addEventListener('click', closeDetail);
+    detail.addEventListener('click', event => {
+      if (event.target === detail) {
+        closeDetail();
+      }
+    });
+    document.addEventListener('keydown', event => {
+      if (event.key === 'Escape' && !detail.hidden) {
+        closeDetail();
+      }
+    });
+    detailBook.addEventListener('click', () => {
+      detailMessage.textContent = 'Reserva iniciada. Aquí aparecería el flujo completo de la ficha de la barbería.';
+    });
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -69,10 +69,13 @@
     }
     .btn:active{background:var(--accent-press);transform:translateY(1px)}
     .promo-badge{
-      display:inline-flex;align-items:center;gap:6px;background:var(--pill);color:#14532d;font-size:12px;font-weight:600;
-      padding:6px 10px;border-radius:999px;margin-bottom:8px;
+      display:inline-flex;align-items:center;gap:6px;
+      background:linear-gradient(135deg,#f59e0b,#d97706);
+      color:#3b2001;font-size:12px;font-weight:700;
+      padding:6px 12px;border-radius:999px;margin-bottom:8px;
+      box-shadow:0 6px 18px rgba(215,119,6,.28);
     }
-    .promo-badge svg{width:16px;height:16px}
+    .promo-badge svg{width:16px;height:16px;stroke:#3b2001}
     .detail{
       position:fixed;inset:0;background:rgba(16,20,24,.55);display:flex;justify-content:center;align-items:flex-end;
       padding:24px;box-sizing:border-box;z-index:20;
@@ -154,7 +157,7 @@
       </article>
 
       <!-- 2 -->
-      <article class="card" data-name="Urban Cuts" data-price="25" data-rating="4.6" data-reviews="210" data-promo="¡Oferta relámpago! Si es tu primera vez, desbloquea 20% de descuento y mensajes VIP que te tientan a reinventarte.">
+      <article class="card" data-name="Urban Cuts" data-price="25" data-rating="4.6" data-reviews="210" data-promo="Oferta de bienvenida: 20% de descuento en tu primera visita y mensajes personalizados con ideas de estilo para animarte a cambiar.">
         <div class="thumb">
           <!-- cool teal studio -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -170,10 +173,10 @@
         </div>
         <div>
           <div class="promo-badge" aria-label="Oferta con mensajes tentadores">
-            <svg viewBox="0 0 24 24" fill="none" stroke="#1d3b31" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M4 6h16v12H4z"/><path d="M4 6l8 6 8-6"/>
             </svg>
-            ¡Oferta relámpago! 20% OFF para nuevos looks
+            Oferta de bienvenida · 20% primera visita
           </div>
           <h3 class="title">Urban Cuts</h3>
           <p class="sub">Desde 25 €</p>
@@ -231,7 +234,7 @@
       </article>
 
       <!-- 5 -->
-      <article class="card" data-name="Style Street Barbers" data-price="29" data-rating="4.7" data-reviews="87" data-promo="¡Descuento secreto! Si es tu primera visita, te mandamos alertas chispeantes con upgrades gratis para que no cambies de idea.">
+      <article class="card" data-name="Style Street Barbers" data-price="29" data-rating="4.7" data-reviews="87" data-promo="Beneficio para nuevos clientes: crédito de 15 € en la primera reserva y mensajes con recomendaciones premium que te invitan a probar mejoras exclusivas.">
         <div class="thumb">
           <!-- dark moody -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -242,10 +245,10 @@
         </div>
         <div>
           <div class="promo-badge" aria-label="Oferta con mensajes tentadores">
-            <svg viewBox="0 0 24 24" fill="none" stroke="#1d3b31" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M4 6h16v12H4z"/><path d="M4 6l8 6 8-6"/>
             </svg>
-            ¡Descuento secreto! Alertas chispeantes
+            Bonificación nuevos clientes · Crédito 15 €
           </div>
           <h3 class="title">Style Street Barbers</h3>
           <p class="sub">Desde 29 €</p>
@@ -326,7 +329,7 @@
       </article>
 
       <!-- 9 -->
-      <article class="card" data-name="Trim &amp; Proper" data-price="17" data-rating="4.5" data-reviews="89" data-promo="¡Promo cambiacitos! Mensajes sorpresa con barba spa gratis si reservas ya mismo.">
+      <article class="card" data-name="Trim &amp; Proper" data-price="17" data-rating="4.5" data-reviews="89" data-promo="Ventaja limitada: barba spa incluida si reservas esta semana y mensajes recordatorio con propuestas de cambio de look para que no lo dejes pasar.">
         <div class="thumb">
           <!-- green walls -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -337,10 +340,10 @@
         </div>
         <div>
           <div class="promo-badge" aria-label="Oferta con mensajes tentadores">
-            <svg viewBox="0 0 24 24" fill="none" stroke="#1d3b31" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M4 6h16v12H4z"/><path d="M4 6l8 6 8-6"/>
             </svg>
-            ¡Promo cambiacitos! Barba spa gratis
+            Ventaja limitada · Barba spa incluida
           </div>
           <h3 class="title">Trim &amp; Proper</h3>
           <p class="sub">Desde 17 €</p>


### PR DESCRIPTION
## Summary
- add promotional badges to highlighted barberías with messaging about ofertas
- remove the extra spacer gap so all cards mantienen la misma separación
- crear una ficha emergente que se abre al pulsar "Reservar" con datos de la barbería

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e2fbf44ee08329a0c5341e5246cdbd