### PR TITLE
Broaden Spanish barbershop listing names

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
            use data-name, data-price, data-rating, data-reviews for quick edits -->
       
       <!-- 1 -->
-      <article class="card" data-name="The Gentlemen’s Den" data-price="18" data-rating="4.9" data-reviews="98">
+      <article class="card" data-name="Studio 4" data-price="18" data-rating="4.9" data-reviews="98">
         <div class="thumb">
           <!-- Barbershop photo style: warm wood -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -144,7 +144,7 @@
           </svg>
         </div>
         <div>
-          <h3 class="title">The Gentlemen’s Den</h3>
+          <h3 class="title">Studio 4</h3>
           <p class="sub">Desde 18 €</p>
           <div class="row">
             <div class="stars" aria-label="4.9 de 5">
@@ -157,7 +157,7 @@
       </article>
 
       <!-- 2 -->
-      <article class="card" data-name="Urban Cuts" data-price="25" data-rating="4.6" data-reviews="210" data-promo="Oferta de bienvenida: 20% de descuento en tu primera visita y mensajes personalizados con ideas de estilo para animarte a cambiar.">
+      <article class="card" data-name="Shave the Sailor" data-price="25" data-rating="4.6" data-reviews="210" data-promo="Oferta de bienvenida: 20% de descuento en tu primera visita y mensajes personalizados con ideas de estilo para animarte a cambiar.">
         <div class="thumb">
           <!-- cool teal studio -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -178,7 +178,7 @@
             </svg>
             Oferta de bienvenida · 20% primera visita
           </div>
-          <h3 class="title">Urban Cuts</h3>
+          <h3 class="title">Shave the Sailor</h3>
           <p class="sub">Desde 25 €</p>
           <div class="row">
             <div class="stars"><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span></div>
@@ -189,7 +189,7 @@
       </article>
 
       <!-- 3 -->
-      <article class="card" data-name="Sharp &amp; Dapper" data-price="21" data-rating="4.7" data-reviews="124">
+      <article class="card" data-name="Sebas &amp; Co" data-price="21" data-rating="4.7" data-reviews="124">
         <div class="thumb">
           <!-- vintage brown leather -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -199,7 +199,7 @@
           </svg>
         </div>
         <div>
-          <h3 class="title">Sharp &amp; Dapper</h3>
+          <h3 class="title">Sebas &amp; Co</h3>
           <p class="sub">Desde 21 €</p>
           <div class="row">
             <div class="stars"><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span></div>
@@ -210,7 +210,7 @@
       </article>
 
       <!-- 4 -->
-      <article class="card" data-name="Elite Barbershop" data-price="19" data-rating="4.8" data-reviews="132">
+      <article class="card" data-name="Carlos Conde Peluqueros" data-price="19" data-rating="4.8" data-reviews="132">
         <div class="thumb">
           <!-- bright studio -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -223,7 +223,7 @@
           </svg>
         </div>
         <div>
-          <h3 class="title">Elite Barbershop</h3>
+          <h3 class="title">Carlos Conde Peluqueros</h3>
           <p class="sub">Desde 19 €</p>
           <div class="row">
             <div class="stars"><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span></div>
@@ -234,7 +234,7 @@
       </article>
 
       <!-- 5 -->
-      <article class="card" data-name="Style Street Barbers" data-price="29" data-rating="4.7" data-reviews="87" data-promo="Beneficio para nuevos clientes: crédito de 15 € en la primera reserva y mensajes con recomendaciones premium que te invitan a probar mejoras exclusivas.">
+      <article class="card" data-name="Malayerba" data-price="29" data-rating="4.7" data-reviews="87" data-promo="Beneficio para nuevos clientes: crédito de 15 € en la primera reserva y mensajes con recomendaciones premium que te invitan a probar mejoras exclusivas.">
         <div class="thumb">
           <!-- dark moody -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -250,7 +250,7 @@
             </svg>
             Bonificación nuevos clientes · Crédito 15 €
           </div>
-          <h3 class="title">Style Street Barbers</h3>
+          <h3 class="title">Malayerba</h3>
           <p class="sub">Desde 29 €</p>
           <div class="row">
             <div class="stars"><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span></div>
@@ -261,7 +261,7 @@
       </article>
 
       <!-- 6 -->
-      <article class="card" data-name="Master’s Touch" data-price="23" data-rating="4.9" data-reviews="109">
+      <article class="card" data-name="Greyhound Barbershop" data-price="23" data-rating="4.9" data-reviews="109">
         <div class="thumb">
           <!-- copper vibe -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -273,7 +273,7 @@
           </svg>
         </div>
         <div>
-          <h3 class="title">Master’s Touch</h3>
+          <h3 class="title">Greyhound Barbershop</h3>
           <p class="sub">Desde 23 €</p>
           <div class="row">
             <div class="stars"><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span></div>
@@ -284,7 +284,7 @@
       </article>
 
       <!-- 7 -->
-      <article class="card" data-name="The Barber Lounge" data-price="18" data-rating="4.6" data-reviews="176">
+      <article class="card" data-name="La Navaja Barber Shop" data-price="18" data-rating="4.6" data-reviews="176">
         <div class="thumb">
           <!-- steel/industrial -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -294,7 +294,7 @@
           </svg>
         </div>
         <div>
-          <h3 class="title">The Barber Lounge</h3>
+          <h3 class="title">La Navaja Barber Shop</h3>
           <p class="sub">Desde 18 €</p>
           <div class="row">
             <div class="stars"><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span></div>
@@ -305,7 +305,7 @@
       </article>
 
       <!-- 8 -->
-      <article class="card" data-name="Downtown Barber" data-price="20" data-rating="4.8" data-reviews="154">
+      <article class="card" data-name="BlackStone Barcelona" data-price="20" data-rating="4.8" data-reviews="154">
         <div class="thumb">
           <!-- brick wall -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -318,7 +318,7 @@
           </svg>
         </div>
         <div>
-          <h3 class="title">Downtown Barber</h3>
+          <h3 class="title">BlackStone Barcelona</h3>
           <p class="sub">Desde 20 €</p>
           <div class="row">
             <div class="stars"><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span></div>
@@ -329,7 +329,7 @@
       </article>
 
       <!-- 9 -->
-      <article class="card" data-name="Trim &amp; Proper" data-price="17" data-rating="4.5" data-reviews="89" data-promo="Ventaja limitada: barba spa incluida si reservas esta semana y mensajes recordatorio con propuestas de cambio de look para que no lo dejes pasar.">
+      <article class="card" data-name="Barbers Crew Valencia" data-price="17" data-rating="4.5" data-reviews="89" data-promo="Ventaja limitada: barba spa incluida si reservas esta semana y mensajes recordatorio con propuestas de cambio de look para que no lo dejes pasar.">
         <div class="thumb">
           <!-- green walls -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -345,7 +345,7 @@
             </svg>
             Ventaja limitada · Barba spa incluida
           </div>
-          <h3 class="title">Trim &amp; Proper</h3>
+          <h3 class="title">Barbers Crew Valencia</h3>
           <p class="sub">Desde 17 €</p>
           <div class="row">
             <div class="stars"><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span></div>
@@ -356,7 +356,7 @@
       </article>
 
       <!-- 10 -->
-      <article class="card" data-name="Classic Cuts" data-price="18" data-rating="4.7" data-reviews="134">
+      <article class="card" data-name="The Barber Club Madrid" data-price="18" data-rating="4.7" data-reviews="134">
         <div class="thumb">
           <!-- classic chairs -->
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
@@ -366,7 +366,7 @@
           </svg>
         </div>
         <div>
-          <h3 class="title">Classic Cuts</h3>
+          <h3 class="title">The Barber Club Madrid</h3>
           <p class="sub">Desde 18 €</p>
           <div class="row">
             <div class="stars"><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span><span class="star"></span></div>
@@ -375,7 +375,7 @@
           </div>
         </div>
       </article>
-      <article class="card" data-name="Fade Masters" data-price="22" data-rating="4.9" data-reviews="156">
+      <article class="card" data-name="The Gentlecat" data-price="22" data-rating="4.9" data-reviews="156">
         <div class="thumb">
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
             <rect width="200" height="200" fill="#1e3a8a"/>
@@ -384,7 +384,7 @@
           </svg>
         </div>
         <div>
-          <h3 class="title">Fade Masters</h3>
+          <h3 class="title">The Gentlecat</h3>
           <p class="sub">Desde 22 €</p>
           <div class="row">
             <div class="stars">
@@ -396,7 +396,7 @@
         </div>
       </article>
     
-      <article class="card" data-name="Barber Republic" data-price="20" data-rating="4.7" data-reviews="120">
+      <article class="card" data-name="Dr. Barber Sevilla" data-price="20" data-rating="4.7" data-reviews="120">
         <div class="thumb">
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
             <rect width="200" height="200" fill="#7f1d1d"/>
@@ -405,7 +405,7 @@
           </svg>
         </div>
         <div>
-          <h3 class="title">Barber Republic</h3>
+          <h3 class="title">Dr. Barber Sevilla</h3>
           <p class="sub">Desde 20 €</p>
           <div class="row">
             <div class="stars">
@@ -417,7 +417,7 @@
         </div>
       </article>
     
-      <article class="card" data-name="Gent’s Corner" data-price="19" data-rating="4.8" data-reviews="97">
+      <article class="card" data-name="The Experience Barber Shop" data-price="19" data-rating="4.8" data-reviews="97">
         <div class="thumb">
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
             <rect width="200" height="200" fill="#14532d"/>
@@ -426,7 +426,7 @@
           </svg>
         </div>
         <div>
-          <h3 class="title">Gent’s Corner</h3>
+          <h3 class="title">The Experience Barber Shop</h3>
           <p class="sub">Desde 19 €</p>
           <div class="row">
             <div class="stars">
@@ -438,7 +438,7 @@
         </div>
       </article>
     
-      <article class="card" data-name="Royal Clippers" data-price="24" data-rating="4.9" data-reviews="183">
+      <article class="card" data-name="Barbería Ruzafa" data-price="24" data-rating="4.9" data-reviews="183">
         <div class="thumb">
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
             <rect width="200" height="200" fill="#78350f"/>
@@ -447,7 +447,7 @@
           </svg>
         </div>
         <div>
-          <h3 class="title">Royal Clippers</h3>
+          <h3 class="title">Barbería Ruzafa</h3>
           <p class="sub">Desde 24 €</p>
           <div class="row">
             <div class="stars">
@@ -459,7 +459,7 @@
         </div>
       </article>
     
-      <article class="card" data-name="Empire Cuts" data-price="23" data-rating="4.6" data-reviews="131">
+      <article class="card" data-name="La Barbería de Salamanca" data-price="23" data-rating="4.6" data-reviews="131">
         <div class="thumb">
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
             <rect width="200" height="200" fill="#3f3f46"/>
@@ -468,7 +468,7 @@
           </svg>
         </div>
         <div>
-          <h3 class="title">Empire Cuts</h3>
+          <h3 class="title">La Barbería de Salamanca</h3>
           <p class="sub">Desde 23 €</p>
           <div class="row">
             <div class="stars">
@@ -480,7 +480,7 @@
         </div>
       </article>
     
-      <article class="card" data-name="Next Level Barbers" data-price="25" data-rating="4.8" data-reviews="142">
+      <article class="card" data-name="Barbería Vintage 54" data-price="25" data-rating="4.8" data-reviews="142">
         <div class="thumb">
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
             <rect width="200" height="200" fill="#312e81"/>
@@ -489,7 +489,7 @@
           </svg>
         </div>
         <div>
-          <h3 class="title">Next Level Barbers</h3>
+          <h3 class="title">Barbería Vintage 54</h3>
           <p class="sub">Desde 25 €</p>
           <div class="row">
             <div class="stars">
@@ -501,7 +501,7 @@
         </div>
       </article>
     
-      <article class="card" data-name="King’s Touch" data-price="26" data-rating="4.9" data-reviews="165">
+      <article class="card" data-name="La Barbería de Córdoba Centro" data-price="26" data-rating="4.9" data-reviews="165">
         <div class="thumb">
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
             <rect width="200" height="200" fill="#164e63"/>
@@ -510,7 +510,7 @@
           </svg>
         </div>
         <div>
-          <h3 class="title">King’s Touch</h3>
+          <h3 class="title">La Barbería de Córdoba Centro</h3>
           <p class="sub">Desde 26 €</p>
           <div class="row">
             <div class="stars">
@@ -522,7 +522,7 @@
         </div>
       </article>
     
-      <article class="card" data-name="La Esquina del Barbero" data-price="18" data-rating="4.7" data-reviews="88">
+      <article class="card" data-name="La Barbería de Horta" data-price="18" data-rating="4.7" data-reviews="88">
         <div class="thumb">
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
             <rect width="200" height="200" fill="#6b21a8"/>
@@ -531,7 +531,7 @@
           </svg>
         </div>
         <div>
-          <h3 class="title">La Esquina del Barbero</h3>
+          <h3 class="title">La Barbería de Horta</h3>
           <p class="sub">Desde 18 €</p>
           <div class="row">
             <div class="stars">
@@ -543,7 +543,7 @@
         </div>
       </article>
     
-      <article class="card" data-name="Urban Fade Lab" data-price="21" data-rating="4.8" data-reviews="175">
+      <article class="card" data-name="Bonhomia Barber Shop" data-price="21" data-rating="4.8" data-reviews="175">
         <div class="thumb">
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
             <rect width="200" height="200" fill="#4338ca"/>
@@ -552,7 +552,7 @@
           </svg>
         </div>
         <div>
-          <h3 class="title">Urban Fade Lab</h3>
+          <h3 class="title">Bonhomia Barber Shop</h3>
           <p class="sub">Desde 21 €</p>
           <div class="row">
             <div class="stars">
@@ -564,7 +564,7 @@
         </div>
       </article>
     
-      <article class="card" data-name="The Blade Room" data-price="27" data-rating="4.9" data-reviews="201">
+      <article class="card" data-name="La Moderna Barber Shop" data-price="27" data-rating="4.9" data-reviews="201">
         <div class="thumb">
           <svg width="100%" height="100%" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
             <rect width="200" height="200" fill="#881337"/>
@@ -573,7 +573,7 @@
           </svg>
         </div>
         <div>
-          <h3 class="title">The Blade Room</h3>
+          <h3 class="title">La Moderna Barber Shop</h3>
           <p class="sub">Desde 27 €</p>
           <div class="row">
             <div class="stars">


### PR DESCRIPTION
## Summary
- replace the repetitive "Barbería …" entries with a mix of real Spanish barbers such as Studio 4, Shave the Sailor, Sebas & Co o Bonhomia Barber Shop para diversificar el listado
- ajustar los atributos de datos y títulos de las tarjetas para reflejar los nuevos nombres manteniendo precios, valoraciones y promociones

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e6dc3c22fc8329b1d437657b56c905